### PR TITLE
[DOCS] Fix markdown linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<!-- markdownlint-disable first-line-h1 -->
-<!-- markdownlint-disable html -->
-<!-- markdownlint-disable no-duplicate-header -->
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+<!-- markdownlint-disable MD024 -->
 
 <div align="center">
   <img src="open_thoughts.png" width="60%" alt="Open Thoughts GitHub Repository" />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- markdownlint-disable first-line-h1 -->
 <!-- markdownlint-disable html -->
 <!-- markdownlint-disable no-duplicate-header -->
@@ -14,14 +13,13 @@
     <img alt="Hugging Face" src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Open%20Thoughts-blue?color=ffc107&logoColor=white&style=flat&link=https%3A%2F%2Fhuggingface.co/open-thoughts">
   </a>
   <br>
-  <i>Curating the best open reasoning datasets</i><br> 
+  <i>Curating the best open reasoning datasets</i><br>
   A collaboration led by <a href="https://bespokelabs.ai/">Bespoke Labs</a> and the <a href="https://www.datacomp.ai/">DataComp</a> community
 
 </p>
 <hr>
 
 Our first goal is to curate a reasoning dataset to train state-of-the-art small reasoning models that surpass [DeepSeek-R1-Distill-Qwen-32B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B) and [DeepSeek-R1-Distill-Qwen-7B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B) on math and code reasoning benchmarks.
-
 
 # News
 <!-- - **[2025/02/16]** 🎉 [OpenThinker on Ollama](https://ollama.com/library/openthinker) reaches 500k downloads. -->
@@ -35,9 +33,11 @@ Our first goal is to curate a reasoning dataset to train state-of-the-art small 
 - **[2025/01/22]** 🎉 [Bespoke-Stratos-17k dataset](https://huggingface.co/datasets/bespokelabs/Bespoke-Stratos-17k) and [Bespoke-Stratos-32B model](https://huggingface.co/bespokelabs/Bespoke-Stratos-32B) are [announced](https://www.bespokelabs.ai/blog/bespoke-stratos-the-unreasonable-effectiveness-of-reasoning-distillation).
 
 # Results
+
 The numbers reported in the table below are evaluated with our open-source tool [Evalchemy](https://github.com/mlfoundations/Evalchemy).
 
 [OpenThinker-32B](https://huggingface.co/open-thoughts/OpenThinker-32B) vs other 32B models:
+
 | Model Name                   |  AIME24 | AIME25 I | MATH500 | GPQA-Diamond | LCBv2 All|
 | ---------------------------- | ------ | -------- | ------- | ------ | ----- |
 | OpenThinker-32B              |  66.0   | 53.3     | 90.6    | 61.6   | 68.9  |
@@ -47,6 +47,7 @@ The numbers reported in the table below are evaluated with our open-source tool 
 | DeepSeek-R1-Distill-Qwen-32B |  76.7   | 55.9     | 89.4    | 57.6   | 71.2  |
 
 [OpenThinker-7B](https://huggingface.co/open-thoughts/OpenThinker-7B) vs other 7B models:
+
 |                             | AIME24   | MATH500 | GPQA-Diamond | LCBv2 Easy  | LCBv2 Medium  | LCBv2 Hard  | LCBv2 All  |
 | --------------------------- | -------- | ------- | ------------ | ----------- | ------------- | ----------- | ---------- |
 | OpenThinker-7B              | 31.3     | 83.0    | 42.4         | 75.3        | 28.6          | 6.5         | 39.9       |
@@ -57,28 +58,32 @@ The numbers reported in the table below are evaluated with our open-source tool 
 
 Note: The AIME24 dataset has a small sample size, resulting in high variance in evaluation accuracy. To mitigate this, we updated the code to compute the average score over five evaluation runs with different seeds. No system prompt is used, the maximum token length is set to 32,768, and temperature is 0.7.
 
-We are fully open-source. Our [model weights](https://huggingface.co/open-thoughts), [datasets](https://huggingface.co/open-thoughts), [data generation code](https://github.com/open-thoughts/open-thoughts), [evaluation code](https://github.com/mlfoundations/Evalchemy), and [training code](https://github.com/hiyouga/LLaMA-Factory) are all publicly available. 
+We are fully open-source. Our [model weights](https://huggingface.co/open-thoughts), [datasets](https://huggingface.co/open-thoughts), [data generation code](https://github.com/open-thoughts/open-thoughts), [evaluation code](https://github.com/mlfoundations/Evalchemy), and [training code](https://github.com/hiyouga/LLaMA-Factory) are all publicly available.
 
-|  | Open Weights | Open Data | Open Code | 
-|--|--------------|-----------| --------- |
+| Model | Open Weights | Open Data | Open Code |
+|-------|--------------|-----------| --------- |
 |OpenThinker-7B|✅|[✅](https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k)|[✅](https://github.com/open-thoughts/open-thoughts) |
 |Bespoke-Stratos-7B|✅|[✅](https://huggingface.co/datasets/bespokelabs/Bespoke-Stratos-17k)|[✅](https://github.com/bespokelabsai/curator/tree/main/examples/bespoke-stratos-data-generation)|
 |DeepSeek-R1-Distill-Qwen-7B|✅|❌|❌|
-|gpt-4o-0513|❌|❌|❌|❌|
-|o1-mini|❌|❌|❌|❌|
+|gpt-4o-0513|❌|❌|❌|
+|o1-mini|❌|❌|❌|
 
 # Installation
-```
+
+```sh
 make install
 poetry shell
 ```
+
 Set the DeepSeek API key:
-```
+
+```sh
 export DEEPSEEK_API_KEY=your_api_key
 ```
 
 Set HF_ORG to your organization id. Set HF_PRIVATE=true if you want to push to a private repo.
-```
+
+```sh
 export HF_ORG=your_org_id
 export HF_PRIVATE=false
 ```
@@ -86,6 +91,7 @@ export HF_PRIVATE=false
 # Data Generation
 
 Currently, we are generating data for the following domains:
+
 1. Code
 2. Math
 3. Science
@@ -99,11 +105,12 @@ The recipe is outlined below:
 
 More instructions are in [open_thoughts/README.md](open_thoughts/README.md).
 
-
 # Training and Evaluation
+
 Training and evaluation code coming soon.
 
 # Links
+
 - 📊 [Open Thoughts Launch Blog Post](https://www.open-thoughts.ai/blog/launch)
 - 🧠 [OpenThoughts-114k dataset](https://huggingface.co/datasets/open-thoughts/OpenThoughts-114k)
 - 🧠 [OpenThoughts-Unverified-173k dataset](https://huggingface.co/datasets/open-thoughts/OpenThoughts-Unverified-173k)
@@ -115,7 +122,8 @@ Training and evaluation code coming soon.
 - 🤖 [Bespoke-Stratos-7B model](https://huggingface.co/bespokelabs/Bespoke-Stratos-7B)
 
 # Citation
-```
+
+```misc
 @misc{Open Thoughts,
   author = {Open Thoughts Team},
   month = jan,
@@ -129,7 +137,9 @@ Training and evaluation code coming soon.
 We are a team of researchers and engineers from [Bespoke Labs](https://www.bespokelabs.ai/), Stanford, University of California Berkeley, University of Washington, Juelich Supercomputing Center (JSC), LAION, UCLA, UNC Chapel Hill, UT Austin, and Toyota Research Institute united around building the best datasets (and thus the best models). See our previous works at [datacomp.ai](https://www.datacomp.ai/) and [mlfoundations](https://github.com/mlfoundations).
 
 # Sponsors
-Open Thoughts is supported by 
+
+Open Thoughts is supported by:
+
 - [Bespoke Labs](https://www.bespokelabs.ai/)
 - [Lambda Labs](https://lambdalabs.com/)
 - [NSF IFML](https://www.ifml.institute/)

--- a/open_thoughts/README.md
+++ b/open_thoughts/README.md
@@ -1,21 +1,26 @@
+<!-- markdownlint-disable first-line-h1 -->
+<!-- markdownlint-disable no-duplicate-heading -->
+
 # Data Generation
 
 Set up the environment and HF as outlined in the parent README.
 
 Set the DeepSeek API key:
-```
+
+```sh
 export DEEPSEEK_API_KEY=your_api_key
 ```
 
 Set HF_ORG to your organization id. Set HF_PRIVATE=true if you want to push to a private repo.
-```
+
+```sh
 export HF_ORG=your_org_id
 export HF_PRIVATE=false
 ```
 
+Cached responses make iteration time faster. If you want to regenerate without caching, set the following.
 
-Cached responses make iteration time faster. If you want to regenerate without caching, set the following. 
-```
+```sh
 export CURATOR_DISABLE_CACHE=true
 ```
 
@@ -27,7 +32,7 @@ First run with the `--dry-run` flag to run on a small subset of the data.
 
 This will push the math dataset (along with intermediate datasets) to the HuggingFace dataset `{HF_ORG}/open-thoughts-math`.
 
-```
+```sh
 python open_thoughts/math/maths.py --dry-run
 ```
 
@@ -37,7 +42,7 @@ This will push the code dataset (along with intermediate datasets) to the Huggin
 
 **WARNING**: This code when run without `--dry-run` uses the `deepmind/code_contests` [dataset](https://huggingface.co/datasets/deepmind/code_contests), which is >100 GB. Make sure you have enough disk space.
 
-```
+```sh
 python open_thoughts/code/code.py --dry-run
 ```
 
@@ -45,7 +50,7 @@ python open_thoughts/code/code.py --dry-run
 
 This will push the science dataset (along with intermediate datasets) to the HuggingFace dataset `{HF_ORG}/open-thoughts-science`.
 
-```
+```sh
 python open_thoughts/science/science.py --dry-run
 ```
 
@@ -53,19 +58,17 @@ python open_thoughts/science/science.py --dry-run
 
 This will push the puzzle dataset (along with intermediate datasets) to the HuggingFace dataset `{HF_ORG}/open-thoughts-puzzle`.
 
-```
+```sh
 python open_thoughts/puzzle/puzzle.py --dry-run
 ```
-
 
 ## Combine and verify
 
 After running the above, you can combine the datasets and run verification using:
 
-```
+```sh
 python open_thoughts/mix.py --dry-run
 ```
-
 
 ## Source Datasets
 
@@ -80,12 +83,11 @@ python open_thoughts/mix.py --dry-run
 3. [codeparrot/apps](https://huggingface.co/datasets/codeparrot/apps)
 4. [deepmind/code_contests](https://huggingface.co/datasets/deepmind/code_contests)
 
-### Science 
+### Science
 
 1. [camel-ai/physics](https://huggingface.co/datasets/camel-ai/physics)
 2. [camel-ai/chemistry](https://huggingface.co/datasets/camel-ai/chemistry)
 3. [camel-ai/biology](https://huggingface.co/datasets/camel-ai/biology)
-
 
 ### Puzzle
 

--- a/open_thoughts/README.md
+++ b/open_thoughts/README.md
@@ -1,5 +1,4 @@
-<!-- markdownlint-disable first-line-h1 -->
-<!-- markdownlint-disable no-duplicate-heading -->
+<!-- markdownlint-disable MD024 -->
 
 # Data Generation
 

--- a/train/README.md
+++ b/train/README.md
@@ -3,6 +3,7 @@
 We train [OpenThinker-7B](https://huggingface.co/open-thoughts/OpenThinker-7B) and [OpenThinker-32B](https://huggingface.co/open-thoughts/OpenThinker-32B) using a modified version of [LLaMa-Factory](https://github.com/hiyouga/LLaMA-Factory).
 
 We provide our training config files with the relevant hyperparameters:
+
 - [`OpenThinker-7B.yaml`](./OpenThinker-7B.yaml)
 - [`OpenThinker-32B.yaml`](./OpenThinker-32B.yaml)
 


### PR DESCRIPTION
DOCS only.

* fix linting in all 3 README.md files
* replace disable of markdown-lint with more reliable alternative
* fix red crosses one column too much for
```
|gpt-4o-0513|❌|❌|❌|❌|
|o1-mini|❌|❌|❌|❌|
```